### PR TITLE
Add MOJAQ (cookieless, EU-hosted analytics) to Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   * Analytics
     * [Matomo](https://matomo.org/) - Matomo is the leading open-source analytics platform that gives you more than just powerful analytics. Can be self hosted or cloud hosted.
     * [Fathom](https://usefathom.com/) - Fathom, simple analytics for bloggers & businesses
+    * [MOJAQ](https://mojaq.com) - Cookieless, EU-hosted (Helsinki) analytics with no consent banner needed.
   * Checklist
     * [GDPR Checklist](https://gdprchecklist.io) - The GDPR Compliance Checklist - This is a basic checklist you can use to harden your GDPR compliancy.
   * Maps
@@ -30,4 +31,3 @@
 ## What is GDPR ?
 
 The General Data Protection Regulation is a new EU regulation enforced since 25 May 2018.
-


### PR DESCRIPTION
Adds MOJAQ to the **Analytics** section, alongside Matomo and Fathom.

MOJAQ is cookieless, EU-hosted (Helsinki) web analytics that needs no consent banner, no US data transfers, and a DPA is included, which fits the list's focus on GDPR-compliant tools for website creators.

Disclosure: I'm involved with the project. Thanks for curating this list!